### PR TITLE
Replace deprecated IO

### DIFF
--- a/lib/File/Directory/Tree.pm
+++ b/lib/File/Directory/Tree.pm
@@ -1,6 +1,5 @@
 module File::Directory::Tree;
 
-
 multi sub mktree (Cool:D $path is copy, Int :$mask = 0o777 ) is export {
 	return True if $path.IO ~~ :d;
 	$path.=IO;
@@ -14,7 +13,6 @@ multi sub mktree (Cool:D $path is copy, Int :$mask = 0o777 ) is export {
 	}
 	True;
 }
-
 
 multi sub empty-directory (Cool:D $path is copy) {
     empty-directory $path.IO;
@@ -41,4 +39,3 @@ multi sub rmtree (IO::Path:D $path) is export {
 	rmdir($path.IO) or return False;
 	True;
 }
-

--- a/lib/File/Directory/Tree.pm
+++ b/lib/File/Directory/Tree.pm
@@ -3,7 +3,7 @@ module File::Directory::Tree;
 
 multi sub mktree (Cool:D $path is copy, Int :$mask = 0o777 ) is export {
 	return True if $path.IO ~~ :d;
-	$path.=path;
+	$path.=IO;
 	my @makedirs;
 	while $path !~~ :e {
 		@makedirs.push($path);
@@ -17,7 +17,7 @@ multi sub mktree (Cool:D $path is copy, Int :$mask = 0o777 ) is export {
 
 
 multi sub empty-directory (Cool:D $path is copy) {
-    empty-directory $path.path;
+    empty-directory $path.IO;
 }
 
 multi sub empty-directory (IO::Path:D $path) is export {
@@ -31,14 +31,14 @@ multi sub empty-directory (IO::Path:D $path) is export {
 }
 
 multi sub rmtree (Cool:D $path is copy) {
-    rmtree $path.path ;
+    rmtree $path.IO;
 }
 
 multi sub rmtree (IO::Path:D $path) is export {
 	return True if !$path.e;
 	$path.d or fail "$path is not a directory";
-	empty-directory($path.path) or return False;
-	rmdir($path.path) or return False;
+	empty-directory($path.IO) or return False;
+	rmdir($path.IO) or return False;
 	True;
 }
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,3 +1,4 @@
+use v6;
 use Test;
 use File::Directory::Tree;
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -7,8 +7,8 @@ plan 7;
 ok (my $tmpdir = $*TMPDIR), "We can haz a tmpdir";
 $tmpdir or skip_rest "for EPIC FAIL at finding a place to write";
 
-my $tmppath = $tmpdir.path;
-ok mktree($tmppath.child( 
+my $tmppath = $tmpdir.path.IO;
+ok mktree($tmppath.child(
     $*SPEC.catdir( "foo", "bar", $*SPEC.updir, "baz")).Str ), "mktree runs";
 ok $tmppath.child("foo").d, '$TEMP/foo exists';
 ok $tmppath.child('foo').dir.elems == 2, "mktree produces correct number of elements";

--- a/t/basic.t
+++ b/t/basic.t
@@ -18,3 +18,5 @@ ok rmtree($tmppath.child("foo")), "rmtree runs";
 ok $tmppath.child("foo").e.not, "rmtree successfully deletes temp files";
 
 done;
+
+# vim: expandtab shiftwidth=4 ft=perl6

--- a/t/basic.t
+++ b/t/basic.t
@@ -7,13 +7,13 @@ plan 7;
 ok (my $tmpdir = $*TMPDIR), "We can haz a tmpdir";
 $tmpdir or skip_rest "for EPIC FAIL at finding a place to write";
 
-my $tmppath = $tmpdir.path.IO;
+my $tmppath = $tmpdir.IO;
 ok mktree($tmppath.child(
     $*SPEC.catdir( "foo", "bar", $*SPEC.updir, "baz")).Str ), "mktree runs";
 ok $tmppath.child("foo").d, '$TEMP/foo exists';
 ok $tmppath.child('foo').dir.elems == 2, "mktree produces correct number of elements";
 ok spurt("$tmpdir/foo/filetree.tmp", "temporary test file, delete after reading"), "created a test file";
-say "# ", "$tmpdir/foo".path.dir;
+say "# ", "$tmpdir/foo".IO.dir;
 ok rmtree($tmppath.child("foo")), "rmtree runs";
 ok $tmppath.child("foo").e.not, "rmtree successfully deletes temp files";
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -4,7 +4,7 @@ use File::Directory::Tree;
 
 plan 7;
 
-ok (my $tmpdir = IO::Spec.tmpdir), "We can haz a tmpdir";
+ok (my $tmpdir = $*TMPDIR), "We can haz a tmpdir";
 $tmpdir or skip_rest "for EPIC FAIL at finding a place to write";
 
 my $tmppath = $tmpdir.path;

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,5 +1,6 @@
 use v6;
 use Test;
+use lib 'lib';
 use File::Directory::Tree;
 
 plan 7;


### PR DESCRIPTION
The `.path` method of `IO::Spec` is deprecated and will be removed as of Rakudo version 2015.09.  These changes replace the `.path` method with the recommended `.IO` role.  All tests pass and the deprecation warnings no longer appear.  Some of the commits are simple tidy-ups which can be skipped if desired.