### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/File/Directory/Tree.pm
+++ b/lib/File/Directory/Tree.pm
@@ -1,4 +1,4 @@
-module File::Directory::Tree;
+unit module File::Directory::Tree;
 
 multi sub mktree (Cool:D $path is copy, Int :$mask = 0o777 ) is export {
 	return True if $path.IO ~~ :d;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.