### PR TITLE
Use a randomly generated subdirectory name in TEMPDIR

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -6,17 +6,22 @@ use File::Directory::Tree;
 plan 7;
 
 ok (my $tmpdir = $*TMPDIR), "We can haz a tmpdir";
-$tmpdir or skip_rest "for EPIC FAIL at finding a place to write";
+$tmpdir or skip-rest "for EPIC FAIL at finding a place to write";
 
 my $tmppath = $tmpdir.IO;
+my $tmpfn;
+repeat {
+    $tmpfn = (2**32).rand.Int.fmt("%8.8X");
+    { skip-rest 'Could not find a place to put tests'; last } if ++$ > 10;
+} while $tmppath.child($tmpfn).e;
 ok mktree($tmppath.child(
-    $*SPEC.catdir( "foo", "bar", $*SPEC.updir, "baz")).Str ), "mktree runs";
-ok $tmppath.child("foo").d, '$TEMP/foo exists';
-ok $tmppath.child('foo').dir.elems == 2, "mktree produces correct number of elements";
-ok spurt("$tmpdir/foo/filetree.tmp", "temporary test file, delete after reading"), "created a test file";
-say "# ", "$tmpdir/foo".IO.dir;
-ok rmtree($tmppath.child("foo")), "rmtree runs";
-ok $tmppath.child("foo").e.not, "rmtree successfully deletes temp files";
+    $*SPEC.catdir( $tmpfn, "bar", $*SPEC.updir, "baz")).Str ), "mktree runs";
+ok $tmppath.child($tmpfn).d, '$TEMP/' ~ $tmpfn ~ ' exists';
+ok $tmppath.child($tmpfn).dir.elems == 2, "mktree produces correct number of elements";
+ok spurt("$tmpdir/$tmpfn/filetree.tmp", "temporary test file, delete after reading"), "created a test file";
+say "# ", "$tmpdir/$tmpfn".IO.dir;
+ok rmtree($tmppath.child($tmpfn)), "rmtree runs";
+ok $tmppath.child($tmpfn).e.not, "rmtree successfully deletes temp files";
 
 done;
 


### PR DESCRIPTION
  This avoids install failures when someone has a "/tmp/foo" already.
Also use hypenated forms of Test.pm functions