### PR TITLE
Ensure we do not leak open handles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/lib/.precomp

--- a/lib/File/Directory/Tree.pm
+++ b/lib/File/Directory/Tree.pm
@@ -20,7 +20,7 @@ multi sub empty-directory (Cool:D $path is copy) {
 
 multi sub empty-directory (IO::Path:D $path) is export {
 	$path.d or fail "$path is not a directory";
-	for $path.dir -> $file {
+	for eager $path.dir -> $file {
 		#say $file.perl;
 		if $file.l.not and $file.d { rmtree $file }
 		else { unlink $file }

--- a/t/basic.t
+++ b/t/basic.t
@@ -3,7 +3,7 @@ use Test;
 use lib 'lib';
 use File::Directory::Tree;
 
-plan 7;
+plan 9;
 
 ok (my $tmpdir = $*TMPDIR), "We can haz a tmpdir";
 $tmpdir or skip-rest "for EPIC FAIL at finding a place to write";
@@ -22,6 +22,14 @@ ok spurt("$tmpdir/$tmpfn/filetree.tmp", "temporary test file, delete after readi
 say "# ", "$tmpdir/$tmpfn".IO.dir;
 ok rmtree($tmppath.child($tmpfn)), "rmtree runs";
 ok $tmppath.child($tmpfn).e.not, "rmtree successfully deletes temp files";
+
+with $*TMPDIR.child: 'file-directory-tree-module-tests' {
+  my $inner = $_;
+  $inner = $inner.child('a').mkdir for ^120;
+  ok .&rmtree, 'no handles leaked by rmtree (requires '
+    ~ '`ulimit -n 100` or lower to test properly)';
+  ok .e.not,   'dir with inner dirs is gone';
+}
 
 done-testing;
 


### PR DESCRIPTION
`.dir` uses up a filehandle handle until its `Seq` is exhausted, so
currently we use up a handle per directory level we recurse into.
This causes the routine to crash on systems with low open files
limit, or in programs that open up a lot of handles prior to calling
our routines.

Fix by evaluating .dir eagerly, so it closes its handle before recurse.

I also included a test covering this bug, but it needs `ulimit -n 100` set to test the stuff properly.
