### PR TITLE
Fix version

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -2,7 +2,7 @@
   "perl"        : "6.*",
   "name"        : "File::Directory::Tree",
   "license"     : "Artistic-2.0",
-  "version"     : "*",
+  "version"     : "0.0.1",
   "description" : "Create and delete directory trees",
   "auth"        : "labster",
   "authors"     : [ "Brent Laabs", "Paul Cochrane", "Zoffix Znet" ],


### PR DESCRIPTION
using `*` as version doesn't seem right, since it can match any version. I think a distribution version need to be specific.